### PR TITLE
Open Hideout Helm at start when game length set to short

### DIFF
--- a/lzr.lua
+++ b/lzr.lua
@@ -573,7 +573,7 @@ settings = {
 	gameLengths = 1,
 };
 
-keys_short = {3, 8}; -- Only works for Glitched runs
+keys_short = {3, 8};
 keys_med = {3, 6, 7, 8};
 keys_long = {1,2,3,4,5,6,7,8};
 

--- a/modules/finalHelmDoors.lua
+++ b/modules/finalHelmDoors.lua
@@ -9,6 +9,6 @@ if settings.gameLengths < 2 then
 	fileFlagsCount = #newFileFlags;
 	newFileFlags[fileFlagsCount + 1] = {0x60,4}; -- Crown Door
 	newFileFlags[fileFlagsCount + 2] = {0x60,2}; -- BoM Off
-	newFileFlags[fileFlagsCount + 3] = {0x38,1}; -- Key 6
-	newFileFlags[fileFlagsCount + 4] = {0x38,2}; -- Key 7
+	newFileFlags[fileFlagsCount + 3] = {0x38,1}; -- Key 6 Turned
+	newFileFlags[fileFlagsCount + 4] = {0x38,2}; -- Key 7 Turned
 end

--- a/modules/finalHelmDoors.lua
+++ b/modules/finalHelmDoors.lua
@@ -9,4 +9,6 @@ if settings.gameLengths < 2 then
 	fileFlagsCount = #newFileFlags;
 	newFileFlags[fileFlagsCount + 1] = {0x60,4}; -- Crown Door
 	newFileFlags[fileFlagsCount + 2] = {0x60,2}; -- BoM Off
+	newFileFlags[fileFlagsCount + 3] = {0x38,1}; -- Key 6
+	newFileFlags[fileFlagsCount + 4] = {0x38,2}; -- Key 7
 end


### PR DESCRIPTION
### What this change does

This change sets Hideout Helm to be open when a new game is started and game length is set to short.

This is achieved by setting the key 6 and 7 turned flags to true.

### What sparked this change

[2Dos labelled this a bug in the #bug_reports channel on the Randomizer discord.](https://canary.discordapp.com/channels/463917049782075395/550798722733178919/554555193082249216)

### Why make this change

Currently on short the final boss K. Rool fight is accessible with the collection of both keys 3 and 8. 
However without the use of glitches key 8 requires keys 6 and 7 to be turned.

This change makes the short game mode easier especially for casual players who do not know glitches.